### PR TITLE
fix zh-cn typo

### DIFF
--- a/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
+++ b/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
@@ -32,7 +32,7 @@ return {
   },
   open_crafting_view_key_description = {
     en = "Opens the Crafting view.",
-    ["zh-cn"] = "打开 0-7-7 海德昂界面。",
+    ["zh-cn"] = "打开 O-7-7 海德昂界面。",
   },
   -- credits_vendor_background_view
   open_credits_vendor_view_key = {


### PR DESCRIPTION
LOL I want to use npcs' full title in zh-cn translation, but I have a typo for "Omega-7-7"

It's minor, no need to publish a new release for that