### PR TITLE
feat: enable hotkeys in psykanium

### DIFF
--- a/scripts/mods/hub_hotkey_menus/hub_hotkey_menus.lua
+++ b/scripts/mods/hub_hotkey_menus/hub_hotkey_menus.lua
@@ -38,8 +38,17 @@ local is_in_hub = function()
 	end
 end
 
+local is_in_psykanium = function()
+	if Managers and Managers.state and Managers.state.game_mode then
+		return Managers.state.game_mode:game_mode_name() == "shooting_range"
+	end
+end
+
 local can_activate_hub_view = function(ui_manager, view)
-	return is_in_hub() and (not ui_manager:chat_using_input()) and (not ui_manager:has_active_view(view))
+	if (not is_in_hub()) and (not (is_in_psykanium() and mod:get("enable_in_psykanium"))) then
+		return false
+	end
+	return (not ui_manager:chat_using_input()) and (not ui_manager:has_active_view(view))
 end
 
 local activate_hub_view = function(view)

--- a/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_data.lua
+++ b/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_data.lua
@@ -7,6 +7,11 @@ return {
   options = {
     widgets = {
       {
+        setting_id      = "enable_in_psykanium",
+        type            = "checkbox",
+        default_value   = true,
+      },
+      {
         setting_id      = "open_barber_view_key",
         type            = "keybind",
         default_value   = {},

--- a/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
+++ b/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
@@ -7,6 +7,14 @@ return {
     en = "Open various menus from the hub world with hotkeys.",
     ["zh-cn"] = "通过快捷键打开哀星号上的各种菜单。",
   },
+  enable_in_psykanium = {
+    en = "Enable in Psykanium",
+    ["zh-cn"] = "在灵能室启用",
+  },
+  enable_in_psykanium_description = {
+    en = "Enable hotkeys in Psykanium.",
+    ["zh-cn"] = "在灵能室启用快捷键。",
+  },
   -- barber_vendor_background_view
   open_barber_view_key = {
     en = "Barber",


### PR DESCRIPTION
yes these menus work in psykanium, with minor ui glitch (I only see one small white background when upgrading a weapon)

you can check the mission board, but you cannot start matchmaking there