### PR TITLE
Add open penance view option

### DIFF
--- a/scripts/mods/hub_hotkey_menus/hub_hotkey_menus.lua
+++ b/scripts/mods/hub_hotkey_menus/hub_hotkey_menus.lua
@@ -189,6 +189,10 @@ mod.activate_commissary_view = function(self)
 	activate_hub_view("cosmetics_vendor_background_view")
 end
 
+mod.activate_penance_overview_view = function(self)
+	activate_hub_view("penance_overview_view")
+end
+
 -- mod.activate_main_menu_view = function(self)
 -- 	activate_hub_view("main_menu_background_view")
 -- end

--- a/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_data.lua
+++ b/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_data.lua
@@ -105,6 +105,14 @@ return {
         keybind_type    = "function_call",
         function_name   = "activate_commissary_view",
       },
+      {
+        setting_id      = "open_penance_view_key",
+        type            = "keybind",
+        default_value   = {},
+        keybind_trigger = "pressed",
+        keybind_type    = "function_call",
+        function_name   = "activate_penance_overview_view",
+      },
       -- {
       --   setting_id      = "open_main_menu_view_key",
       --   type            = "keybind",

--- a/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
+++ b/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
@@ -147,9 +147,11 @@ return {
   open_penance_view_key = {
     en = "Shrine Penitentax",
     ["zh-cn"] = "神龛忏悔者",
+    ru = "Искупления",
   },
   open_penance_view_key_description = {
     en = "Opens the Penance view.",
     ["zh-cn"] = "打开苦修界面。",
+    ru = "Открывает меню Искуплений.",
   },
 }

--- a/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
+++ b/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
@@ -146,8 +146,10 @@ return {
   },
   open_penance_view_key = {
     en = "Shrine Penitentax",
+    ["zh-cn"] = "神龛忏悔者",
   },
   open_penance_view_key_description = {
     en = "Opens the Penance view.",
+    ["zh-cn"] = "打开苦修界面。",
   },
 }

--- a/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
+++ b/scripts/mods/hub_hotkey_menus/hub_hotkey_menus_localization.lua
@@ -144,4 +144,10 @@ return {
     ["zh-cn"] = "打开杂货店界面。",
     ru = "Открывает меню магазина Косметических предметов.",
   },
+  open_penance_view_key = {
+    en = "Shrine Penitentax",
+  },
+  open_penance_view_key_description = {
+    en = "Opens the Penance view.",
+  },
 }


### PR DESCRIPTION
Penances have become much more of a 'thing' in the latest patch (1.3.0) and now require opening a menu to 'claim'. I've added the ability to open this view to the mod. 

Perhaps @xsSplater and @deluxghost could add the Chinese and Russian localisations?